### PR TITLE
GN_DR-246 gemcook/ganttを公開する。

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,12 @@
 .PHONY: start
 .PHONY: build
+.PHONY: publish
 
 start: build
 	open ./index.html
 
 build:
 	yarn run rollup -c
+
+publish:
+	yarn publish --access public

--- a/README.md
+++ b/README.md
@@ -4,7 +4,25 @@
 ## Getting Start
 
 
+### Install
+
+
 `yarn add @gemcook/gantt`
+
+
+### Import
+
+
+**JavaScript**
+
+
+`import Gantt from '@gemcook/gantt';`
+
+
+**SCSS**
+
+
+`@import '~@gemcook/gantt/lib/styles/index';`
 
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gemcook/gantt",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A simple, modern, interactive gantt library for the web",
   "main": "lib/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gemcook/gantt",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A simple, modern, interactive gantt library for the web",
   "main": "lib/index.js",
   "files": [
@@ -9,6 +9,7 @@
     "LICENSE"
   ],
   "scripts": {
+    "prepublishOnly": "make build",
     "test": "jest",
     "test:watch": "jest --watch"
   },


### PR DESCRIPTION
### 課題 URL


- https://nishio-pj.backlog.com/view/GN_DR-246


### 動作確認ブランチ


| **frontend**     | **backend** |
| :--------------- | :---------- |
| _current branch_ | develop     |


### 動作確認方法


1. README の Getting Start に従ってライブラリを導入する


### アサイニーが確認した項目


- 問題なく動作すること


### 技術的変更点


- ライブラリを publish しました
- Makefile に publish するためのコマンドを追記しました
- publish 時に動作する `prepublishOnly` コマンドを package.json に追記しております


### レビュアーに対する注意点


- 2回、ビルドせずに空の状態で publish しているために動作するバージョンが 0.1.2 からになります


### 課題とは直接関係がないが修正した項目


なし。


### 今回保留した項目


なし。


### リリース・マージに対する注意点


なし。


### その他

なし。
