### PR TITLE
GN_DR-235 ガントチャート部分の土曜日・日曜日に色を付ける。

### DIFF
--- a/src/date_utils.js
+++ b/src/date_utils.js
@@ -300,20 +300,20 @@ export default {
 
     // Dateオブジェクトを受け取り曜日の文字を返す関数
     get_day_of_week(date, lang = 'en') {
-        const dayOfWeek = date.getDay();
-        return day_of_week_names[lang][dayOfWeek];
+        const day_of_week = date.getDay();
+        return day_of_week_names[lang][day_of_week];
     },
 
     // 受け取ったDateが日曜日ならtrueを返す
     is_sunday(date) {
-        const dayOfWeek = date.getDay();
-        return dayOfWeek === 0;
+        const day_of_week = date.getDay();
+        return day_of_week === 0;
     },
 
     // 受け取ったDateが土曜日ならfalseを返す
     is_staday(date) {
-        const dayOfWeek = date.getDay();
-        return dayOfWeek === 6;
+        const day_of_week = date.getDay();
+        return day_of_week === 6;
     }
 };
 

--- a/src/date_utils.js
+++ b/src/date_utils.js
@@ -302,6 +302,18 @@ export default {
     get_day_of_week(date, lang = 'en') {
         const dayOfWeek = date.getDay();
         return day_of_week_names[lang][dayOfWeek];
+    },
+
+    // 受け取ったDateが日曜日ならtrueを返す
+    is_sunday(date) {
+        const dayOfWeek = date.getDay();
+        return dayOfWeek === 0;
+    },
+
+    // 受け取ったDateが土曜日ならfalseを返す
+    is_staday(date) {
+        const dayOfWeek = date.getDay();
+        return dayOfWeek === 6;
     }
 };
 

--- a/src/gantt.scss
+++ b/src/gantt.scss
@@ -39,6 +39,16 @@ $handle-color: #ddd !default;
 		fill: $light-yellow;
 		opacity: 0.5;
 	}
+	
+	.staday-highlight {
+		fill: $handle-color;
+		opacity: 0.3;
+	}
+
+	.sunday-highlight {
+		fill: $handle-color;
+		opacity: 0.3;
+	}
 
 	.arrow {
 		fill: none;

--- a/src/index.js
+++ b/src/index.js
@@ -449,6 +449,7 @@ export default class Gantt {
 
             // dateの配列を回し、土曜日・日曜日だった場合背景に色を付ける
             for (let date of this.dates) {
+                // ガント全体から、x軸の位置を取得する
                 const x =
                     date_utils.diff(date, this.gantt_start, 'hour') /
                     this.options.step *

--- a/src/index.js
+++ b/src/index.js
@@ -430,6 +430,7 @@ export default class Gantt {
         }
     }
 
+    // 縦のハイライトを追加する
     make_grid_highlights() {
         // highlight today's date
         if (this.view_is('Day')) {
@@ -445,6 +446,36 @@ export default class Gantt {
                     this.tasks.length +
                 this.options.header_height +
                 this.options.padding / 2;
+
+            // dateの配列を回し、土曜日・日曜日だった場合背景に色を付ける
+            for (let date of this.dates) {
+                const x =
+                    date_utils.diff(date, this.gantt_start, 'hour') /
+                    this.options.step *
+                    this.options.column_width;
+
+                if (date_utils.is_staday(date)) {
+                    createSVG('rect', {
+                        x,
+                        y,
+                        width,
+                        height,
+                        class: 'staday-highlight',
+                        append_to: this.layers.grid
+                    });
+                }
+
+                if (date_utils.is_sunday(date)) {
+                    createSVG('rect', {
+                        x,
+                        y,
+                        width,
+                        height,
+                        class: 'sunday-highlight',
+                        append_to: this.layers.grid
+                    });
+                }
+            }
 
             createSVG('rect', {
                 x,


### PR DESCRIPTION
### 動作確認方法

`make start` コマンドを実行する

1. 土曜日・日曜日の縦列に背景色があたっていることを確認

### アサイニーが確認した項目

土曜日・日曜日の日付が正しく、縦列に背景色が当たっていることを確認
土曜日・日曜日でそれぞれ違うクラス名が当たっていることを確認

### 技術的変更点

- Dateオブジェクトの getDay() を使用し、土曜日・日曜日を判定しています。
- 土曜日・日曜日だった場合、縦列を作成して背景色を当てています。

### レビュアーに対する注意点

- 全体的なソースコードに合わせて、スネークケースで関数名・変数名を記載しています。
- 土曜日・日曜日を判定する共通関数を作成・使用しています。

### 課題とは直接関係がないが修正した項目

- キャメルケースになっていた変数名を、スネークケースに修正

### 今回保留した項目

なし

### リリース・マージに対する注意点

なし

### その他

なし
